### PR TITLE
fix: modify dashboard chart's API and reloading on viewmode reclick

### DIFF
--- a/src/containers/dashboard/DashboardChart.jsx
+++ b/src/containers/dashboard/DashboardChart.jsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import { useEffect } from 'react'
 import axios from 'axios'
 import Loading from '../../components/Loading'
+import { LOCAL_API_URL, API_URL } from '../../constants'
 
 const ChartDashboard = () => {
   const [viewMode, setViewMode] = useState('week')
@@ -15,14 +16,15 @@ const ChartDashboard = () => {
 
   const handleViewModeChange = (mode) => {
     setViewMode(mode);
+    getChartData(mode);
   };
 
-  const getChartData = async () => {
+  const getChartData = async (mode) => {
     setIsLoading(true)
     setChartError('')
-    if (viewMode === 'week') {
+    if (mode === 'week') {
       try {
-        const response = await axios.get(`${process.env.VITE_APP_API_URL}/payment/chartinfo?week=true`)
+        const response = await axios.get(`${LOCAL_API_URL || API_URL}/payment/chartinfo?week=true`)
         const weekPayments = {
           labels: ['Sun', 'Mon', 'Tue', 'Wed', 'Thur', 'Fri', 'Sat'],
           datasets: [
@@ -43,7 +45,7 @@ const ChartDashboard = () => {
         setChartError('Loading payment data failed. Please try again!')
         console.log(error);
       } 
-    } else if (viewMode === 'month') {
+    } else if (mode === 'month') {
       try {
         let todayDate = new Date();
 
@@ -70,7 +72,7 @@ const ChartDashboard = () => {
         setChartError('Loading payment data failed. Please try again!')
         console.log(error);
       }
-    } else if (viewMode === 'year') {
+    } else if (mode === 'year') {
       try {
         let todayDate = new Date();
 
@@ -100,8 +102,8 @@ const ChartDashboard = () => {
     }
   }
   useEffect(() => {
-    getChartData()    
-  }, [viewMode])
+    getChartData(viewMode)    
+  }, [])
 
   const { isOpen } = useSelector((state) => state.sidebar);
 


### PR DESCRIPTION

## What does this PR do?
- Fixes how API url env variable was being used
- Adds reloading chart when same view mode is being selected as the previous
## Description of Task to be completed?
Fix chart failing to get data on week mode and inability to reload on reclicking the same view mode as the previous
## How should this be manually tested?

- Clone the repository using `git clone https://github.com/IMENA-SOFTEK-LTD/umusanzu-bn.git`

- Checkout to the branch using `git checkout ft-updateDashboardChart`

- Install node packages that the application depends on: `npm i`

- Create a `.env` file in the root directory and add all environment variables required to run the application. The required variables are listed in the `.env.example` file available in root directory of the application.

- Start the application development server: `npm run dev`

- Navigate to the dashboard chart.