### PR TITLE
Feature: add household type editing at agent level

### DIFF
--- a/src/components/models/UpdateHousehold.jsx
+++ b/src/components/models/UpdateHousehold.jsx
@@ -45,6 +45,7 @@ const UpdateHousehold = ({ household }) => {
       phone1: data?.phone1,
       phone2: data?.phone2,
       ubudehe: data?.ubudehe,
+      type: data?.type,
     })
   }
 
@@ -173,7 +174,7 @@ useEffect(() => {
               <Controller
                 control={control}
                 name="type"
-                defaultValue={1}
+                defaultValue={household?.type}
                 render={({ field }) => {
                   return (
                     <select
@@ -183,8 +184,8 @@ useEffect(() => {
                       <option disabled value="">
                         Select household type
                       </option>
-                      <option value={1}>Residence</option>
-                      <option value={2}>Business</option>
+                      <option value={'residence'}>Residence</option>
+                      <option value={'business'}>Business</option>
                     </select>
                   )
                 }}

--- a/src/components/table/Table.jsx
+++ b/src/components/table/Table.jsx
@@ -77,7 +77,7 @@ const Table = ({
   } = TableInstance
 
   const calculateTotals = () => {
-    if (data.length > 0 && data[1].monthlyTarget) {
+    if (data.length > 0 && data[0].hasOwnProperty('monthlyTarget')) {
       const monthlyTargetTotal = data.reduce((acc, row) =>
         acc + parseFloat(row.monthlyTarget.replace(/,/g, '')),
         0);
@@ -241,7 +241,7 @@ const Table = ({
                     </tr>
                     {totalsCalculated !== null ? (
                       <tr className="bg-white text-[15px] divide-y divide-gray-200 w-full font-bold">
-                        <td colSpan={6} className="px-3 py-4 text-center text-ellipsis w-fit">
+                        <td colSpan={4} className="px-3 py-4 text-center text-ellipsis w-fit">
                           TOTALS
                         </td>
                         <td className="px-3 py-4 text-center text-ellipsis w-fit">{totalsCalculated.monthlyTargetTotal}</td>

--- a/src/containers/dashboard/HouseholdTable.jsx
+++ b/src/containers/dashboard/HouseholdTable.jsx
@@ -144,7 +144,8 @@ const HouseholdTable = ({ user }) => {
           cell: row?.cells[0]?.name,
           sector: row?.sectors[0]?.name,
           district: row?.districts[0]?.name,
-          province: row?.provinces[0]?.name,         
+          province: row?.provinces[0]?.name,
+          type: row?.type,         
         })) || []
       )
     }
@@ -179,6 +180,7 @@ const HouseholdTable = ({ user }) => {
                 sector: row?.sectors[0]?.name,
                 district: row?.districts[0]?.name,
                 province: row?.provinces[0]?.name,
+                type: row?.type,
               })) || []
             )
           })

--- a/src/containers/households/HouseholdInfo.jsx
+++ b/src/containers/households/HouseholdInfo.jsx
@@ -40,6 +40,17 @@ const HouseholdInfo = ({ household }) => {
                 <td className="py-2 pl-4">{household?.nid}</td>
               </tr>
               <tr className="border-b border-gray-300">
+                <td className="py-2 pr-4 font-semibold">Household type</td>
+                <td className="py-2 pl-4">
+                <td className="py-2 pl-4">{household?.type}</td>  
+                  {/* <select className="border-[2px] rounded-[2px] border-[#155E75] outline-[#155E75] w-2/3 text-xs"> 
+                    <option value='residence' className='text-xs'> {'Residence'} </option>
+                    <option value='business' className='text-xs'> {'Business'} </option>
+                              
+                  </select> */}
+                </td>
+              </tr>
+              <tr className="border-b border-gray-300">
                 <td className="py-2 pr-4 font-semibold">Amount</td>
                 <td className="py-2 pl-4">
                   {household?.ubudehe} ({household?.currency || 'RWF'})

--- a/src/containers/households/HouseholdInfo.jsx
+++ b/src/containers/households/HouseholdInfo.jsx
@@ -1,4 +1,6 @@
 import { useDispatch, useSelector } from 'react-redux'
+import { useState } from 'react'
+import axios from 'axios'
 import {
   setUpdateHouseholdModal,
   setUpdateHouseholdStatusModal,
@@ -6,13 +8,38 @@ import {
 import Button from '../../components/Button'
 import UpdateHousehold from '../../components/models/UpdateHousehold'
 import UpdateHouseholdStatus from '../../components/models/UpdateHouseholdStatus'
+import { toast } from 'react-toastify'
 
 const HouseholdInfo = ({ household }) => {
 
   // STATE VARIABLES
   const dispatch = useDispatch()
   const { user } = useSelector((state) => state.auth)
+  const [ selectedHouseholdType, setSelectedHouseholdType ] = useState(household?.type)
+  const [displaySave, setDisplaySave] = useState(false) 
 
+
+  const updateHouseHoldType = () => { 
+    axios.patch(
+      `https://v2.umusanzu.rw/api/v2/households/types/${household?.id}`,
+      {
+        type: selectedHouseholdType
+      },
+      {
+        headers: {
+          'Authorization': `Bearer ${localStorage.getItem('token')}`,
+        },
+      }
+    ).then(response => {
+      response.data.message === 'Success'
+        ? toast.success('Household type updated successfully!', { position: toast.POSITION.TOP_RIGHT })
+        : toast.error('Unable to update household type. Try again.', { position: toast.POSITION.TOP_RIGHT })
+      setDisplaySave(false)
+    }).catch(error => {
+      setSelectedHouseholdType(household?.type)
+      toast.error('Unable to update household type. Try again.', { position: toast.POSITION.TOP_RIGHT })
+    })    
+  }
 
   return (
     <main className="bg-white rounded-lg shadow-lg ring-1 ring-gray-200 p-4 w-full">
@@ -40,15 +67,41 @@ const HouseholdInfo = ({ household }) => {
                 <td className="py-2 pl-4">{household?.nid}</td>
               </tr>
               <tr className="border-b border-gray-300">
-                <td className="py-2 pr-4 font-semibold">Household type</td>
-                <td className="py-2 pl-4">
-                <td className="py-2 pl-4">{household?.type}</td>  
-                  {/* <select className="border-[2px] rounded-[2px] border-[#155E75] outline-[#155E75] w-2/3 text-xs"> 
-                    <option value='residence' className='text-xs'> {'Residence'} </option>
-                    <option value='business' className='text-xs'> {'Business'} </option>
-                              
-                  </select> */}
-                </td>
+                <td className="py-2 pr-4 font-semibold">Household </td>
+                  {user?.departments?.level_id === 6 ? 
+                  <td className="py-2 pl-4">
+                    {displaySave
+                      ? <select
+                          defaultValue={household?.type}
+                          className="border-[2px] rounded-[2px] border-[#155E75] outline-[#155E75] w-2/3 text-xs"
+                          onChange={(e) => {
+                            e.preventDefault();
+                            setSelectedHouseholdType(e.target.value)
+                          }}
+                        > 
+                          <option value='residence' className='text-xs'> {'Residence'} </option>
+                          <option value='business' className='text-xs'> {'Business'} </option>
+                                    
+                        </select>
+                        : selectedHouseholdType}
+                    
+                    {displaySave
+                      ? <button
+                          className="bg-[#e5e7eb] hover:bg-[#d1d5db] text-black py-1 px-2 ml-1 text-xs font-semibold rounded-md"
+                          onClick={updateHouseHoldType}
+                        >Save</button>
+                      : <button
+                          className="bg-[#e5e7eb] hover:bg-[#d1d5db] text-black py-1 px-2 ml-2 text-xs font-semibold rounded-md"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            setDisplaySave(true)
+                          }}
+                        >Edit</button>
+                    }
+                    
+                    
+                  </td>    
+                  : <td className="py-2 pl-4">{household?.type}</td>}
               </tr>
               <tr className="border-b border-gray-300">
                 <td className="py-2 pr-4 font-semibold">Amount</td>

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -133,10 +133,9 @@ const Login = () => {
                     defaultValue=""
                     render={({ field }) => (
                       <label className='flex flex-col gap-2'>
-                        <p>Password</p>
+                         <p className='font-medium'>Password</p>
                         <Input
                           placeholder="*******"
-                          label="Password"
                           type="password"
                           className="w-[90%] mx-auto"
                           value={field.value}

--- a/src/pages/households/HouseholdDetails.jsx
+++ b/src/pages/households/HouseholdDetails.jsx
@@ -136,7 +136,13 @@ const HouseholdDetails = () => {
             </section>
           )}
           <span className="flex w-full gap-6 items-start">
-            <HouseholdPayments household={household} />
+            {household.hasOwnProperty('payments')
+              ? <HouseholdPayments household={household} />
+              : <div className="py-[20%] text-center font-semibold text-lg min-w-[70%]">
+                <p className="mx-auto py-8 px-4 w-[60%] rounded-lg shadow-lg">This household has not made any transactions yet!</p>
+              </div>
+            }
+            
             <HouseholdInfo household={household} />
             <RecordOfflinePayment household={household} />
             <RecordMultipleMonths />

--- a/src/states/api/apiSlice.js
+++ b/src/states/api/apiSlice.js
@@ -210,6 +210,7 @@ export const apiSlice = createApi({
           sector,
           cell,
           village,
+          type,
         }) => ({
           url: `/households`,
           method: 'POST',
@@ -224,6 +225,7 @@ export const apiSlice = createApi({
             sector,
             cell,
             village,
+            type,
           },
         }),
       }),
@@ -535,7 +537,7 @@ export const apiSlice = createApi({
         }),
       }),
       updateHousehold: builder.mutation({
-        query: ({ name, nid, phone1, phone2, ubudehe, id }) => ({
+        query: ({ name, nid, phone1, phone2, ubudehe, id, type }) => ({
           url: `/households/${id}`,
           method: 'PATCH',
           body: {
@@ -544,6 +546,7 @@ export const apiSlice = createApi({
             phone1,
             phone2,
             ubudehe,
+            type,
           },
         }),
       }),


### PR DESCRIPTION
## What does this PR do?
- This PR adds household editing at agent level
- This PR fixes household type not reaching household create and update APIs' payloads
## How should this be manually tested?

- Clone the repository using `git clone https://github.com/IMENA-SOFTEK-LTD/umusanzu-bn.git`

- Checkout to the branch using `git checkout feat-householdTypes`

- Install node packages that the application depends on: `npm i`

- Create a `.env` file in the root directory and add all environment variables required to run the application. The required variables are listed in the `.env.example` file available in root directory of the application.

- Start the application development server: `npm run dev`
