### PR TITLE
Fix: adds fixes for printPDF crashing on performances totals missing

### DIFF
--- a/src/components/table/Export.js
+++ b/src/components/table/Export.js
@@ -117,12 +117,7 @@ const printPDF = async ({ TableInstance, reportName, columns = [], totals }) => 
 
     };
 
-    doc.autoTable({
-      startY: doc.lastAutoTable.finalY + 5,
-      head: false,
-      body: totalsTitle,
-      ...totalsTitleStyles,
-    });
+
 
     const totalsGrid = [
       ['Monthly Target Total: ', 'Monthly Collections Total (Progress): ', 'Total remaining amount (Remain): '],
@@ -142,23 +137,25 @@ const printPDF = async ({ TableInstance, reportName, columns = [], totals }) => 
       },
 
     };
-    doc.autoTable({
-      startY: doc.lastAutoTable.finalY + 0,
-      head: false,
-      body: totalsGrid,
-      ...totalsGridStyles,
-    });
-    
+
+    if (totals !== null) {
+      doc.autoTable({
+        startY: doc.lastAutoTable.finalY + 5,
+        head: false,
+        body: totalsTitle,
+        ...totalsTitleStyles,
+      });
+      doc.autoTable({
+        startY: doc.lastAutoTable.finalY + 0,
+        head: false,
+        body: totalsGrid,
+        ...totalsGridStyles,
+      });
+    }
     
     doc.setFontSize(12);
     doc.setFont('Arial', 'bold');
     
-    doc.text(
-      `Date: ${moment().format('DD-MM-YYYY HH:mm:ss')}`,
-      16,
-      doc.lastAutoTable.finalY + 10
-    );
-
     const customContent = [
       ['BITEGUWE NA:', 'BYEMEJWE NA:'],
       ['', ''],
@@ -178,24 +175,60 @@ const printPDF = async ({ TableInstance, reportName, columns = [], totals }) => 
         1: { cellWidth: 100 },
       },
     };
-    doc.autoTable({
-      startY: doc.lastAutoTable.finalY + 25,
-      head: false,
-      body: customContent,
-      ...customContentStyles,
-    });
-    const cachetResponse = await fetch(cachet);
+
+    if (doc.lastAutoTable.finalY + 90 > doc.internal.pageSize.height) {
+      doc.addPage();
+
+      doc.text(
+        `Date: ${moment().format('DD-MM-YYYY HH:mm:ss')}`,
+        16,40
+      );
+
+      doc.autoTable({
+        startY: 50,
+        head: false,
+        body: customContent,
+        ...customContentStyles,
+      });
+
+      const cachetResponse = await fetch(cachet);
       const cachetData = await cachetResponse.blob();
       const cachetBase64 = await convertBlobToBase64(cachetData);
-
+  
       doc.addImage(cachetBase64, 'PNG', 200, doc.lastAutoTable.finalY - 50, 50, 50);
-
-      // Add the signature image here
+  
+        // Add the signature image here
       const signatureResponse = await fetch(signature);
       const signatureData = await signatureResponse.blob();
       const signatureBase64 = await convertBlobToBase64(signatureData);
-
+  
       doc.addImage(signatureBase64, 'PNG', 20, doc.lastAutoTable.finalY - 50, 50, 50);
+    } else {
+
+      doc.text(
+        `Date: ${moment().format('DD-MM-YYYY HH:mm:ss')}`,
+        16,40
+      );
+
+      doc.autoTable({
+        startY: 50,
+        head: false,
+        body: customContent,
+        ...customContentStyles,
+      });
+      const cachetResponse = await fetch(cachet);
+      const cachetData = await cachetResponse.blob();
+      const cachetBase64 = await convertBlobToBase64(cachetData);
+  
+      doc.addImage(cachetBase64, 'PNG', 200, doc.lastAutoTable.finalY - 50, 50, 50);
+  
+        // Add the signature image here
+      const signatureResponse = await fetch(signature);
+      const signatureData = await signatureResponse.blob();
+      const signatureBase64 = await convertBlobToBase64(signatureData);
+  
+      doc.addImage(signatureBase64, 'PNG', 20, doc.lastAutoTable.finalY - 50, 50, 50);
+    }
 
     doc.save(`${reportName}.pdf`);
   };

--- a/src/components/table/Table.jsx
+++ b/src/components/table/Table.jsx
@@ -172,7 +172,19 @@ const Table = ({
                     }
                     onClick={(e) => {
                       e.preventDefault()
-                      printPDF({ TableInstance, reportName, columns, totals : {monthlyTargetTotal, monthlyCollectionsTotal, differenceTotal} })
+                      totalsCalculated !== null
+                        ? printPDF({
+                          TableInstance, reportName, columns,
+                          totals: {
+                            monthlyTargetTotal: totalsCalculated.monthlyTargetTotal,
+                            monthlyCollectionsTotal: totalsCalculated.monthlyCollectionsTotal,
+                            differenceTotal: totalsCalculated.differenceTotal,
+                          }
+                        })
+                        : printPDF({
+                          TableInstance, reportName, columns,
+                          totals: null
+                        })
                     }}
                   />
                   <Button

--- a/src/containers/dashboard/TransactionTable.jsx
+++ b/src/containers/dashboard/TransactionTable.jsx
@@ -328,12 +328,35 @@ const TransactionTable = ({ user }) => {
           1: { cellWidth: 100 },
         },
       };
-      doc.autoTable({
-        startY: doc.lastAutoTable.finalY + 140,
-        head: false,
-        body: customContent,
-        ...customContentStyles,
-      });
+
+      if (doc.lastAutoTable.finalY + 90 > doc.internal.pageSize.height) {
+        doc.addPage()        
+        doc.text(
+          `Done on: ${moment().format('DD-MM-YYYY HH:mm:ss')}`,
+          16,doc.lastAutoTable.finalY + 20
+        );
+        doc.autoTable({
+          startY: doc.lastAutoTable.finalY + 30,
+          head: false,
+          body: customContent,
+          ...customContentStyles,
+        });
+      } else {
+        
+        doc.text(
+          `Done on : ${moment().format('DD-MM-YYYY HH:mm:ss')}`,
+          16,doc.lastAutoTable.finalY + 20
+        );
+
+        doc.autoTable({
+          startY: doc.lastAutoTable.finalY + 30,
+          head: false,
+          body: customContent,
+          ...customContentStyles,
+        });
+
+      }
+
 
       // Add the cachet image here
       const cachetResponse = await fetch(cachet);
@@ -346,11 +369,8 @@ const TransactionTable = ({ user }) => {
       const signatureResponse = await fetch(signature);
       const signatureData = await signatureResponse.blob();
       const signatureBase64 = await convertBlobToBase64(signatureData);
-      const date = new Date();
-      const dateNow = date.getDate() + '-' + (date.getMonth() + 1) + '-' + date.getFullYear();
 
       doc.addImage(signatureBase64, 'PNG', 20, doc.lastAutoTable.finalY - 50, 50, 50);
-      doc.text(`Done on: ${dateNow}`, 20, doc.lastAutoTable.finalY - 50);
 
       doc.save(`${reportName}.pdf`);
     };


### PR DESCRIPTION
## What does this PR do?
- This PR adds fixes for printpdf crashing when performance totals are missing.
- This PR adds printing the stamps on the next page when remaining space is not enough.
## Description of Task to be completed?

## How should this be manually tested?

- Clone the repository using `git clone https://github.com/IMENA-SOFTEK-LTD/umusanzu-bn.git`

- Checkout to the branch using `git checkout fix-printPDF`

- Install node packages that the application depends on: `npm i`

- Create a `.env` file in the root directory and add all environment variables required to run the application. The required variables are listed in the `.env.example` file available in root directory of the application.

- Start the application development server: `npm run dev`
