### PR TITLE
Fix: fixes country level user not accessing administration levels higher than village on admin creation 

### DIFF
--- a/src/containers/dashboard/DepartmentModals.jsx
+++ b/src/containers/dashboard/DepartmentModals.jsx
@@ -50,7 +50,7 @@ export const DepartmentModals = () => {
           >
             <CreateAgentModel />
             <CreateAdmin />
-            <Button value='Create Admin' className='absolute top-28 right-6 !rounded-lg' onClick={(e) => {
+            <Button value='Create Admin' className='absolute top-16 right-6 !rounded-lg' onClick={(e) => {
               e.preventDefault()
               dispatch(setCreateAdminModal(true))
             }} />

--- a/src/containers/staff/CreateAdmin.jsx
+++ b/src/containers/staff/CreateAdmin.jsx
@@ -238,7 +238,7 @@ const CreateAdmin = () => {
                   options={adminLevels?.map((level) => {
                     return {
                       ...level,
-                      disabled: level?.value <= user?.departments?.level_id,
+                      disabled: level?.value <= user?.departments?.level_id && user?.departments?.level_id !== 5,
                     }
                   })}
                   label="Administration Level"
@@ -261,7 +261,7 @@ const CreateAdmin = () => {
                         text: department?.name,
                         value: department?.id,
                         disabled:
-                          department?.level_id <= user?.departments?.level_id,
+                          department?.level_id <= user?.departments?.level_id && user?.departments?.level_id !== 5,
                       }
                     })}
                     label="Administration Department"
@@ -287,9 +287,9 @@ const CreateAdmin = () => {
               return (
                 <label className="flex flex-col gap-1 items-start w-full">
                   <Input
-                    placeholder="07XX XXX XXX"
+                    placeholder="********"
                     type={'password'}
-                    label="Confirm Password"
+                    label="Password"
                     {...field}
                   />
                   {errors?.password && (
@@ -313,7 +313,7 @@ const CreateAdmin = () => {
               return (
                 <label className="flex flex-col gap-1 items-start w-full">
                   <Input
-                    placeholder="Confirm Password"
+                    placeholder="********"
                     label="Confirm Password"
                     {...field}
                   />


### PR DESCRIPTION
## What does this PR do?
- This PR fixes disabling administration levels higher than village on creating admin by country level user.
## Description of Task to be completed?
- This PR adds access to select any administration level and department for country level user when creating an admin.
## How should this be manually tested?

- Clone the repository using `git clone https://github.com/IMENA-SOFTEK-LTD/umusanzu-bn.git`

- Checkout to the branch using `git checkout feat-loginOTP`

- Install node packages that the application depends on: `npm i`

- Create a `.env` file in the root directory and add all environment variables required to run the application. The required variables are listed in the `.env.example` file available in root directory of the application.

- Start the application development server: `npm run dev`